### PR TITLE
Decluttering `python.rst`

### DIFF
--- a/programming/python.rst
+++ b/programming/python.rst
@@ -1,172 +1,26 @@
-.. _python:
-
-.. warning::
-
-    Some of the idioms on this page are out of date, but they still work.
-    See the NEURON Python tutorial for modern idioms.
-
 Python Language
 ---------------
 
-This document describes installation and basic use of NEURON's Python interface. For information on the modules in the ``neuron`` namespace, see:
+This document describes the basic use of NEURON's Python interface. For information on the modules in the ``neuron`` namespace, see:
 
 .. toctree:: :maxdepth: 1
 
     neuronpython.rst
 
+You can use the hoc function :func:`nrn_load_dll` to load mechanism files 
+as well, e.g. if neurondemo was used earlier so the shared object exists, 
 
-Installation
-~~~~~~~~~~~~
+.. code-block::
+    python
 
-
-Syntax:
-    ``./configure --with-nrnpython ...``
-
-    ``make``
-
-    ``make install``
-
-
-Description:
-    Builds NEURON with Python embedded as an alternative interpreter to HOC. 
-    The Python version used is that found from ``which python``. 
-
-    "make install" automatically does a (``cd src/nrnpython ; python setup.py install --home=<prefix>``)
-    which generally puts the neuron module under <prefix>/lib/python. *Note:* This
-    path then needs to be added to your ``PYTHONPATH`` environment variable.
-    To install in the default system Python directory, manually do the ``cd`` and run
-    ``python setup.py install`` (possibly with a ``sudo``). Be advised that this
-    installs only for one version of Python, so if you use both Python 2 and 3,
-    keep reading.
-
-    Other python related configure arguments are:
-      ``--enable-pysetup=installoption``
-                              Execute 'python setup.py install installoption' as
-                              the last installation step. --disable-pysetup or an
-                              installoption of 'no' means do NOT execute 'python
-                              setup.py...' The default installoption is
-                              '--home=<prefix>'
-                              
-      ``--disable-rx3d``          Do not compile the cython translated 3-d rxd
-                              features
-                              
-      ``--with-nrnpython-only``   configure and make only the nrnpython folder
-
-      ``--with-nrnpython=``desired python binary or ``dynamic``
-                              Python interpreter can be used (default is NO)
-                              Probably need to set PYLIBDIR to find libpython...
-                              and PYINCDIR to find Python.h
-
-      ``--with-pyexe``=desired python binary (when ``--with-nrnpython=dynamic``)
-
-      ``--disable-pysetup``   skips the automatic invocation of ``python setup.py``;
-                              to use Python, this will have to be done manually.
-
-
-
-    I use this script to build a version of NEURON that works with python2.5-7 and python3.5-6
-
-    .. code-block::
-        console
-
-        hines@hines-T7500:~/neuron$ cat bld-nrndynam.sh
-        #!/bin/bash
-
-        cd $HOME/neuron/nrndynam
-
-        ../nrn/configure --prefix=`pwd` --with-paranrn=dynamic \
-          --with-nrnpython=dynamic --with-pyexe=python3 --disable-rx3d
-        rm -r -f src/nrnpython/build
-        make -j 6 install
-
-        ../nrn/configure --prefix=`pwd` --with-paranrn=dynamic \
-          --with-nrnpython=dynamic --with-pyexe=python2 --disable-rx3d \
-          --with-nrnpython-only
-        rm -r -f src/nrnpython/build
-        make -j 6 install
-
-        cd lib/python/neuron
-        cp hoc.cpython-35m-x86_64-linux-gnu.so hoc.cpython-36m-x86_64-linux-gnu.so
-        cd ../../..
-        # or alternatively configure ..; rm...; make... with other versions for --with-pyexe
-
-    Originally I thought that ``nrniv -python ...`` was the best way to launch (and perhaps is
-    for parallel and on many supercomputers). Now, especially with the possibility of many python versions and
-    one (--with-nrnpython=dynamic) version is it is simpler to launch the correct python with only the necessity
-    of a uniform ``export PYTHONPATH=<prefix>/lib/python`` (and it is then a bad idea to install the neuron module
-    in a specific python's site-packages). This gives the possibility of
-    python foo.py
-    python2 foo.py
-    python3.5 foo.py
-    python3.6 foo.py
-    Whereas launching ``nrniv`` would require an environment with the proper ``PYTHONHOME`` and ``PYNRNLIB``
-    The former to avoid the dreaded "site" problem and the latter to ensure the right python library is loaded.
-    In vicious cases of failure to launch due to site problems, the first diagnostic info needed to fix the
-    problem is
-    
-    .. code-block::
-        python
-
-        import site
-        print (site.__file__)
-
-    For launching ``nrniv``,there is a script nrnpyenv.sh that helps determine a correct PYTHONHOME, etc for the
-    default ``python`` executable.
-
-    If launching Python and using parallel neuron simulations there is the issue of who calls MPI_Initial.
-    Default assumes Python will call it (perhaps via ``from mpi4py import MPI``). If that is not the case, force the
-    neuron module to initialize MPI when the neuron module is loaded by setting the environment variable
-    NEURON_INIT_MPI
-
-    If you just can't seem to get nrniv to launch and you don't need Python, you can try
-    ``nrniv -nopython ...``
-    or permanently add
-    ``nopython``: on
-    to $HOME/.nrn.defaults or :file:`<prefix>/share/nrn/lib/nrn.defaults` (c:/nrn/lib/nrn.def on windows)
-
-    You can use the hoc function :func:`nrn_load_dll` to load mechanism files 
-    as well, e.g. if neurondemo was used earlier so the shared object exists, 
-
-    .. code-block::
-        python
-
-        from neuron import h
-        h.nrn_load_dll("$(NEURONHOME)/demo/release/x86_64/.libs/libnrnmech.so")
+    from neuron import h
+    h.nrn_load_dll("$(NEURONHOME)/demo/release/x86_64/.libs/libnrnmech.so")
 
 
 .. _python_accessing_hoc:
 
 Python Accessing HOC
 ~~~~~~~~~~~~~~~~~~~~
-
-
-
-Syntax:
-    ``nrniv -python [file.hoc file.py  -c "python_statement"]``
-
-    ``nrngui -python ...``
-
-    ``neurondemo -python ...``
-
-
-Description:
-    Launches NEURON with Python as the command line interpreter. 
-    File arguments with a .hoc suffix are interpreted using the 
-    Hoc interpreter. File arguments with the .py suffix are interpreted 
-    using the Python interpreter. The -c statement causes python to 
-    execute the statement. 
-    The import statements allow use of the following 
-
-         
-
-----
-
-.. note::
-
-    Most of the following is from the perspective of someone familiar
-    with HOC; for a Python-based introduction to NEURON, see
-    http://neuron.yale.edu/neuron/static/docs/neuronpython/index.html
-
 
 .. class:: neuron.hoc.HocObject
 
@@ -544,43 +398,7 @@ Description:
     .. seealso::
         :meth:`Vector.to_python`, :meth:`Vector.from_python`
 
-         
-
 ----
-
-
-
-.. method:: neuron.hoc.hoc_ac
-
-
-    Syntax:
-        ``import hoc``
-
-        ``double_value = hoc.hoc_ac()``
-
-        ``hoc.hoc_ac(double_value)``
-
-
-    Description:
-        Get and set the hoc global scalar, :data:`hoc_ac_`-variables. 
-        This is obsolete since HocObject 
-        is far more general. 
-
-        .. code-block::
-            python
-
-            import hoc 
-            hoc.hoc_ac(25) 
-            hoc.execute('print hoc_ac_') # prints 25 
-            hoc.execute('hoc_ac_ = 17') 
-            print(hoc.hoc_ac())  # prints 17 
-
-
-         
-
-----
-
-
 
 .. method:: neuron.h.cas
 


### PR DESCRIPTION
This file is linked to as a "basic programming" page and should supposedly show basic how to's with the Python interface. It has several problems:

* It is not written in an introductory style, but rather in a complete reference guide style with very detailed explanations of various non introductory topics.
* I have removed all installation as `pip install NEURON` supercedes them all for any introduction.
* I am planning to still remove basically everything on this page and instead write an introduction with examples of how to use NEURON Python interface, starting from creating a few sections, inserting some mechanisms, compiling & loading their own mechanisms, connecting them together up to loading a morphology with Import3D and instantiating it. The basic necessities for creating a neuron model.